### PR TITLE
[12.0][IMP] connector_jira: write only updated values

### DIFF
--- a/connector_jira/fields.py
+++ b/connector_jira/fields.py
@@ -65,11 +65,3 @@ class MilliDatetime(fields.Field):
                 ", not date." % (value, self)
             )
         return self.from_string(value)
-
-
-def normalize_field_value(field, value):
-    # NOTE: In v13 from_string is likely to go
-    if hasattr(field, 'from_string') and isinstance(value, str):
-        from_string = getattr(field, 'from_string')
-        return from_string(value)
-    return value

--- a/connector_jira/models/project_task/common.py
+++ b/connector_jira/models/project_task/common.py
@@ -6,8 +6,6 @@ from odoo import api, fields, models, exceptions, _
 from odoo.addons.component.core import Component
 from odoo.osv import expression
 
-from ...fields import normalize_field_value
-
 
 class JiraProjectTask(models.Model):
     _name = 'jira.project.task'
@@ -215,16 +213,21 @@ class ProjectTask(models.Model):
     def _connector_jira_write_validate(self, vals):
         if not self.env.context.get('connector_jira') and \
                 self.mapped('jira_bind_ids')._is_linked():
-            normalized_vals = {
-                field: normalize_field_value(self._fields[field], value)
-                for field, value in vals.items()
-            }
-            for current_vals in self.read(
-                    list(vals.keys()), load='_classic_write'):
+            fields = list(vals.keys())
+            new_values = self._convert_to_cache(
+                vals,
+                update=True,
+                validate=False,
+            )
+            for old_values in self.read(fields, load='_classic_write'):
+                old_values = self._convert_to_cache(
+                    old_values,
+                    validate=False,
+                )
                 for field in self._get_connector_jira_fields():
-                    if field not in vals:
+                    if field not in fields:
                         continue
-                    if normalized_vals[field] == current_vals[field]:
+                    if new_values[field] == old_values[field]:
                         continue
                     raise exceptions.UserError(_(
                         'Task linked to JIRA Issue can not be modified!'

--- a/connector_jira/tests/test_import_analytic_line.py
+++ b/connector_jira/tests/test_import_analytic_line.py
@@ -2,7 +2,7 @@
 # Copyright 2019 Brainbean Apps (https://brainbeanapps.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from datetime import date
+from datetime import date, timedelta
 
 from .common import recorder, JiraSavepointCase
 
@@ -108,6 +108,23 @@ class TestImportAccountAnalyticLine(TestImportWorklogBase):
                 'user_id': self.env.user.id,
             }]
         )
+
+    def test_reimport_worklog(self):
+        jira_issue_id = '10000'
+        jira_worklog_id = '10000'
+        with recorder.use_cassette('test_import_worklog.yaml'):
+            binding = self._setup_import_worklog(
+                self.task,
+                jira_issue_id,
+                jira_worklog_id,
+            )
+        write_date = binding.write_date - timedelta(seconds=1)
+        binding.write({
+            'write_date': write_date,
+        })
+        with recorder.use_cassette('test_import_worklog.yaml'):
+            binding.force_reimport()
+        self.assertEqual(binding.write_date, write_date)
 
     @recorder.use_cassette('test_import_worklog.yaml')
     def test_import_worklog_naive(self):


### PR DESCRIPTION
This PR changes how values are updated in order to avoid `write()` calls if nothing changed: such updated behaviour improves compatibility with other plugins and allow keeping write timestamp intact. In addition to that, comparison is now done via cache format.