### PR TITLE
[FIX] set company_id on the task related to the project

### DIFF
--- a/connector_jira/models/project_task/importer.py
+++ b/connector_jira/models/project_task/importer.py
@@ -81,6 +81,7 @@ class ProjectTaskMapper(Component):
         project = binder.unwrap_binding(self.options.project_binding)
         values = {
             "project_id": project.id,
+            "company_id": project.company_id.id,
             "jira_project_bind_id": self.options.project_binding.id,
         }
         if not project.active:


### PR DESCRIPTION
* Purpose
Set the company_id from the project on the task, if not odoo will raise an error
if the company on the project differ from the one that create the job

