### PR TITLE
[13.0][IMP] connector jira unbind jira project task

### DIFF
--- a/connector_jira/__manifest__.py
+++ b/connector_jira/__manifest__.py
@@ -7,6 +7,7 @@
     "license": "AGPL-3",
     "category": "Connector",
     "depends": [
+        "base_automation",
         "connector",
         "project",
         "hr_timesheet",
@@ -44,6 +45,7 @@
         "wizards/jira_account_analytic_line_import_views.xml",
         "security/ir.model.access.csv",
         "data/cron.xml",
+        "data/data.xml",
     ],
     "demo": ["demo/jira_backend_demo.xml"],
     "installable": True,

--- a/connector_jira/data/data.xml
+++ b/connector_jira/data/data.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="automation_task_unbind_jira" model="base.automation">
+        <field name="name">Task: Unbind Jira</field>
+        <field name="model_id" ref="project.model_project_task" />
+        <field name="state">code</field>
+        <field name="trigger">on_write</field>
+        <field
+            name="trigger_field_ids"
+            eval="[(4,ref('project.field_project_task__stage_id'))]"
+        />
+        <field name="code">
+            for record in records:
+    if record.stage_id.unbind_jira:
+        record.jira_bind_ids.write({'external_id': False})
+        record.jira_bind_ids.unlink()
+        </field>
+    </record>
+    <record id="action_task_unbind_jira" model="ir.actions.server">
+        <field name="name">Task: Unbind Jira</field>
+        <field name="model_id" ref="project.model_project_task" />
+        <field name="state">code</field>
+        <field name="code">
+            records.mapped('jira_bind_ids').write({'external_id': False})
+records.mapped('jira_bind_ids').unlink()
+        </field>
+    </record>
+</odoo>

--- a/connector_jira/models/project_task/__init__.py
+++ b/connector_jira/models/project_task/__init__.py
@@ -3,3 +3,4 @@
 from . import common
 from . import importer
 from . import task_link_jira
+from . import project_task_type

--- a/connector_jira/models/project_task/project_task_type.py
+++ b/connector_jira/models/project_task/project_task_type.py
@@ -1,0 +1,12 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from odoo import fields, models
+
+
+class JiraProjectTaskStage(models.Model):
+    _inherit = "project.task.type"
+
+    jira_unbind = fields.Boolean(
+        string="Jira Unbind",
+        help="Cut the link between JIRA and the task when project reached this stage.",
+    )

--- a/connector_jira/views/project_project_views.xml
+++ b/connector_jira/views/project_project_views.xml
@@ -142,4 +142,16 @@
             </xpath>
         </field>
     </record>
+    <record id="view_jira_project_task_type_view_form" model="ir.ui.view">
+        <field name="name">project.task.type.form.inherit.jira</field>
+        <field name="model">project.task.type</field>
+        <field name="inherit_id" ref="project.task_type_edit" />
+        <field name="arch" type="xml">
+            <xpath expr="//sheet" position="inside">
+                <group string="JIRA">
+                    <field name="jira_unbind" />
+                </group>
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
When a project reached a final stage (For example "Done" or "Cancelled"), we don't want to record more timesheet on project tasks. At that moment, the existing binding with JIRA should be cut to prevent time to be added at that stage.