### PR TITLE
[15.0][MIG] connector_jira: fix migration from 14.0

### DIFF
--- a/connector_jira/migrations/15.0.1.0.0/pre-migrate.py
+++ b/connector_jira/migrations/15.0.1.0.0/pre-migrate.py
@@ -1,0 +1,24 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+from openupgradelib import openupgrade
+
+
+def migrate(cr, version):
+    add_missing_xmlid_on_channel(cr)
+
+
+def add_missing_xmlid_on_channel(cr):
+    query = """
+        SELECT id FROM queue_job_channel
+        WHERE complete_name='root.connector_jira.import';
+    """
+    cr.execute(query)
+    channel = cr.fetchall()
+    if channel:
+        openupgrade.add_xmlid(
+            cr,
+            "connector_jira",
+            "import_root",
+            "queue.job.channel",
+            channel[0][0],
+        )


### PR DESCRIPTION
To avoid the creation of another `queue.job.channel` with the same name, triggering the SQL constraint on `complete_name`.